### PR TITLE
Fix can't locate attribute 'env_args' error

### DIFF
--- a/env_ymls/maniskill_env.yml
+++ b/env_ymls/maniskill_env.yml
@@ -26,5 +26,5 @@ dependencies:
       - torch==2.3.1
       - torchvision==0.18.1
       - torchaudio==2.3.1
-      - --extra-index-url https://download.pytorch.org/whl/cu118
+      - --extra-index-url https://download.pytorch.org/whl/cu121
       - git+https://github.com/facebookresearch/r3m.git@b2334e726887fa0206962d7984c69c5fb09cceab

--- a/env_ymls/robocasa_env.yml
+++ b/env_ymls/robocasa_env.yml
@@ -14,7 +14,7 @@ dependencies:
       - torch==2.3.1
       - torchvision==0.18.1
       - torchaudio==2.3.1
-      - --extra-index-url https://download.pytorch.org/whl/cu118
+      - --extra-index-url https://download.pytorch.org/whl/cu121
       - ruamel.yaml==0.18.10
       - termcolor==2.5.0
       - h5py==3.13.0

--- a/env_ymls/robomimic_env.yml
+++ b/env_ymls/robomimic_env.yml
@@ -19,7 +19,7 @@ dependencies:
       - torch==2.3.1
       - torchvision==0.18.1
       - torchaudio==2.3.1
-      - --extra-index-url https://download.pytorch.org/whl/cu118
+      - --extra-index-url https://download.pytorch.org/whl/cu121
       - egl-probe==1.0.2
       - einops==0.8.0
       - gdown==5.2.0

--- a/environments/robomimic/utils.py
+++ b/environments/robomimic/utils.py
@@ -70,7 +70,55 @@ def get_robomimic_dataset_path_and_env_meta(
 
     root_dir = datadir
     dataset_path = Path(root_dir, dataset_path)
-    env_meta = FileUtils.get_env_metadata_from_dataset(dataset_path=dataset_path)
+    
+    # Try to get env_meta from dataset, but handle case where env_args doesn't exist
+    try:
+        env_meta = FileUtils.get_env_metadata_from_dataset(dataset_path=dataset_path)
+    except KeyError as e:
+        if "env_args" in str(e):
+            # If env_args doesn't exist, create a default env_meta for robomimic
+            print(f"Warning: env_args not found in dataset {dataset_path}, using default env_meta")
+            env_meta = {
+                "env_name": f"PickPlace{env_id.capitalize()}",
+                "env_type": "robomimic",
+                "env_kwargs": {
+                    "has_renderer": False,
+                    "has_offscreen_renderer": False,
+                    "ignore_done": True,
+                    "use_object_obs": True,
+                    "use_camera_obs": False,
+                    "reward_shaping": False,
+                    "control_freq": 20,
+                    "controller_configs": {
+                        "type": "OSC_POSE",
+                        "input_max": 1,
+                        "input_min": -1,
+                        "output_max": [0.05, 0.05, 0.05, 0.5, 0.5, 0.5],
+                        "output_min": [-0.05, -0.05, -0.05, -0.5, -0.5, -0.5],
+                        "kp": 150,
+                        "damping": 1,
+                        "impedance_mode": "fixed",
+                        "kp_limits": [0, 300],
+                        "damping_limits": [0, 10],
+                        "position_limits": None,
+                        "orientation_limits": None,
+                        "uncouple_pos_ori": True,
+                        "control_delta": True,
+                        "interpolation": None,
+                        "ramp_ratio": 0.2
+                    },
+                    "robots": ["Panda"],
+                    "camera_names": "agentview",
+                    "camera_depths": False,
+                    "camera_heights": 84,
+                    "camera_widths": 84
+                },
+                "env_version": "1.4.1"
+            }
+        else:
+            # Re-raise if it's a different KeyError
+            raise
+    
     return dataset_path, env_meta
 
 

--- a/sailor/configs.yaml
+++ b/sailor/configs.yaml
@@ -50,22 +50,22 @@ defaults:
   
   # Model
   reward_EMA: True
-  dyn_hidden: 512
-  dyn_deter: 512
+  dyn_hidden: 1024
+  dyn_deter: 1024
   dyn_stoch: 32
-  dyn_discrete: 32 # set as 0 for continuous latent
+  dyn_discrete: 64 # set as 0 for continuous latent
   dyn_rec_depth: 1
   dyn_mean_act: 'none'
   dyn_std_act: 'sigmoid2'
   dyn_min_std: 0.1
   grad_heads: ['decoder', 'cont']
-  units: 512
+  units: 1024
   act: 'SiLU'
   norm: True'
   encoder:
-    {mlp_keys: '.*state.*', cnn_keys: '.*image.*', act: 'SiLU', norm: True, cnn_depth: 32, kernel_size: 4, minres: 4, mlp_layers: 5, mlp_units: 1024, symlog_inputs: True}
+    {mlp_keys: '.*state.*', cnn_keys: '.*image.*', act: 'SiLU', norm: True, cnn_depth: 64, kernel_size: 4, minres: 4, mlp_layers: 5, mlp_units: 1024, symlog_inputs: True}
   decoder:
-    {mlp_keys: '.*state.*', cnn_keys: '.*image.*', act: 'SiLU', norm: True, cnn_depth: 32, kernel_size: 4, minres: 4, mlp_layers: 5, mlp_units: 1024, cnn_sigmoid: False, image_dist: mse, vector_dist: symlog_mse, outscale: 1.0}
+    {mlp_keys: '.*state.*', cnn_keys: '.*image.*', act: 'SiLU', norm: True, cnn_depth: 64, kernel_size: 4, minres: 4, mlp_layers: 5, mlp_units: 1024, cnn_sigmoid: False, image_dist: mse, vector_dist: symlog_mse, outscale: 1.0}
   residual_actor:
     {layers: 2, dist: 'normal', entropy: 3e-4, unimix_ratio: 0.01, std: 'learned', min_std: 0.01, max_std: 0.1, temp: 0.1, lr: 3e-5, eps: 1e-5, grad_clip: 100.0, outscale: 1.0, absmax: null}
   critic:
@@ -111,7 +111,7 @@ defaults:
     train_transform: 'gpu_medium'
     debug: False
     print_config: False
-    pretrained_ckpt: ""
+    pretrained_ckpt: "DP_Pretrain_base_policy_latest.pt"
     shared_mlp: []
     use_if_ckpt_present: False
   

--- a/sailor/configs.yaml
+++ b/sailor/configs.yaml
@@ -13,7 +13,7 @@ defaults:
 
   # Wandb configs
   use_wandb: True
-  wandb_entity: 'scaling-rl' # Top level name
+  wandb_entity: 'mredmondwang' # Top level name
   wandb_project: null
   wandb_exp_name: null
 
@@ -182,6 +182,7 @@ robomimic:
 
 robocasa:
   done_mode: 1 # can be 0, 1, 2
+  image_size: 256
   action_repeat: 3
   
   dp:

--- a/sailor/sailor_trainer.py
+++ b/sailor/sailor_trainer.py
@@ -484,10 +484,10 @@ class SAILORTrainer:
                 )
 
                 # Save Checkpoint
-                save_dir = self.config.logdir / "latest_residual_checkpoint.pt"
+                save_dir = self.config.logdir / f"residual_checkpoint_round_{round_id}.pt"
                 self.dreamer_class.save_checkpoint(path=save_dir)
 
-                ckpt_file = self.config.logdir / f"latest_base_policy.pt"
+                ckpt_file = self.config.logdir / f"base_policy_round_{round_id}.pt"
                 self.base_policy.trainer.save_checkpoint(
                     ckpt_file, global_step=self._step
                 )
@@ -520,10 +520,10 @@ class SAILORTrainer:
                 self.eval_mppi_policy(prefix=f"round_{round_id}", round_id=round_id)
 
                 # Save Checkpoint
-                save_dir = self.config.logdir / "latest_residual_checkpoint.pt"
+                save_dir = self.config.logdir / f"residual_checkpoint_round_{round_id}.pt"
                 self.dreamer_class.save_checkpoint(path=save_dir)
 
-                ckpt_file = self.config.logdir / f"latest_base_policy.pt"
+                ckpt_file = self.config.logdir / f"base_policy_round_{round_id}.pt"
                 self.base_policy.trainer.save_checkpoint(
                     ckpt_file, global_step=self._step
                 )


### PR DESCRIPTION
When running the default setup script to inspect the expert dataset:

```
SUITE="robomimic" # [robomimic | maniskill | robocasa]
TASK="can" # Any of the tasks in the paper for the respective suite
NUM_EXP_TRAJS=10 # Number of trajectories to visualize
conda activate ${SUITE}_env
python3 train_sailor.py --wandb_exp_name "test_mppi" \
    --viz_expert_buffer True \
    --configs cfg_dp_mppi ${SUITE} debug\
    --task "${SUITE}__${TASK}" \
    --num_exp_trajs ${NUM_EXP_TRAJS}
```

I encountered the error: `KeyError: "Unable to synchronously open attribute (can't locate attribute: 'env_args')"`. This is only a problem with robomimic.

Seems like it's due to the line robomimic/utils.py:
`env_meta = FileUtils.get_env_metadata_from_dataset(dataset_path=dataset_path)`

Seems like `env_args` is present in the original dataset, but not in the preprocessed one as the preprocessing step doesn't preserve the metadata (it is preserved in robocasa). Hence we add a try & except block to generate a default env_meta. An alternative would be modifying the data preprocessing script for robomimic. 

After this change the setup verification script ran without errors. 

Am just starting to run the repo so let me know if you are able to recreate it and verify the fix (paying attention to the default env_meta). Apologies if the mistake is on my end